### PR TITLE
Fix language preference loading

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -82,12 +82,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
         }
         
-        // Initialize language selector
+        // Initialize language selector with persisted language if available
         initLanguageSelector((language) => {
             // Save language preference
             storage.saveSettings({ language });
             updateUI();
-        });
+        }, settings.language || 'en');
         console.log('Language selector initialized');
 
         // Load saved icons

--- a/src/js/modules/i18n.js
+++ b/src/js/modules/i18n.js
@@ -110,16 +110,15 @@ function getTranslatedText(key, replacements = {}, language = 'en') {
  * Initialize the language selector and set default language
  * @param {function} onChange - Callback when language changes
  */
-function initLanguageSelector(onChange) {
+function initLanguageSelector(onChange, initialLang = 'en') {
     document.addEventListener('DOMContentLoaded', () => {
         const languageSelect = document.getElementById('languageSelect');
         if (!languageSelect) {
             console.error('Language selector element not found');
             return;
         }
-        
+
         // Set initial language
-        const initialLang = 'en';
         setLanguage(initialLang);
         
         // Set the dropdown to match the initial language


### PR DESCRIPTION
## Summary
- pass saved language to `initLanguageSelector`
- allow `initLanguageSelector` to accept initial language

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0b1316708328a92ee1547282c0f1