### PR TITLE
Fix addImage quality and compression order

### DIFF
--- a/src/js/modules/pdfGenerator.js
+++ b/src/js/modules/pdfGenerator.js
@@ -158,8 +158,8 @@ async function generatePDF(options) {
                                             drawWidth,
                                             drawHeight,
                                             `img-${cell.id}`,
-                                            'FAST',
-                                            imgQuality
+                                            imgQuality,
+                                            'FAST'
                                         );
                                     } catch (imgErr) {
                                         console.error('Error adding image to PDF:', imgErr);


### PR DESCRIPTION
## Summary
- fix parameter order for `addImage` in the PDF generator
- mock `createImageFromBase64` and add test for quality/compression order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0d9aee8c8328b666754bd3069361