### PR TITLE
Implement issue #16 simplifying sheet identifier

### DIFF
--- a/src/js/modules/cardGenerator.js
+++ b/src/js/modules/cardGenerator.js
@@ -239,11 +239,13 @@ function calculateExpectedMultiHitCount(gridSize, leaveCenterBlank, difficulty) 
  * @returns {string} - The generated identifier
  */
 function generateIdentifier() {
-    // Generate a unique set identifier (date + random)
-    const date = new Date();
-    const dateStr = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, '0')}${String(date.getDate()).padStart(2, '0')}`;
-    const randomStr = Math.floor(Math.random() * 10000).toString().padStart(4, '0');
-    return `ID:${dateStr}-${randomStr}`;
+    // Generate a short 3-character alphanumeric identifier
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let id = '';
+    for (let i = 0; i < 3; i++) {
+        id += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return `ID:${id}`;
 }
 
 /**

--- a/tests/js/modules/cardGenerator.test.js
+++ b/tests/js/modules/cardGenerator.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { generateBingoCards, calculateExpectedMultiHitCount, getDifficultySettings } from '@/js/modules/cardGenerator.js';
+import { generateBingoCards, generateIdentifier, calculateExpectedMultiHitCount, getDifficultySettings } from '@/js/modules/cardGenerator.js';
 
 describe('Card Generator', () => {
   beforeEach(() => {
@@ -340,6 +340,11 @@ describe('Card Generator', () => {
       // 5x5 grid with center blank = 24 cells, medium difficulty = 45%
       const expectedWithBlank = calculateExpectedMultiHitCount(5, true, 'MEDIUM');
       expect(expectedWithBlank).toBe(11); // 24 * 0.45 = 10.8, rounded to 11
+    });
+
+    it('should generate a short alphanumeric identifier', () => {
+      const id = generateIdentifier();
+      expect(id).toMatch(/^ID:[A-Z0-9]{3}$/);
     });
 
     it('should return correct difficulty settings', () => {


### PR DESCRIPTION
## Summary
- simplify the sheet identifier generation to use a short alphanumeric code
- test the new identifier format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0ee6c23c8328bac949092655aa0e