### PR TITLE
Fix alignment of Show Labels toggle

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -253,9 +253,10 @@ button:disabled {
   background: #f5f5f5;
 }
 
-/* Ensure toggle is always visible */
+/* Ensure toggle is always visible and aligned */
 #showLabelsToggle, label[for="showLabelsToggle"] {
-  display: inline-block !important;
+  display: flex !important;
+  align-items: center !important;
 }
 
 .generate-section {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -255,8 +255,8 @@ button:disabled {
 
 /* Ensure toggle is always visible and aligned */
 #showLabelsToggle, label[for="showLabelsToggle"] {
-  display: flex !important;
-  align-items: center !important;
+  display: flex;
+  align-items: center;
 }
 
 .generate-section {


### PR DESCRIPTION
## Summary
- keep the "Show text labels on icons" checkbox aligned with other toggles

## Testing
- `npm test` *(fails: PDF Generator › generatePDF › should pass image quality before compression)*

------
https://chatgpt.com/codex/tasks/task_e_685904544c648328b08f9a0cec39b791