### PR TITLE
Fix icon aspect ratio handling in PDF

### DIFF
--- a/src/js/modules/imageUtils.js
+++ b/src/js/modules/imageUtils.js
@@ -137,8 +137,30 @@ function createImageFromBase64(base64Data) {
 }
 
 // Export functions
+/**
+ * Load an image from base64 data and get its natural dimensions
+ * @param {string} base64Data - The base64 encoded image data
+ * @returns {Promise<{width:number,height:number}>} - Promise resolving with dimensions
+ */
+function getImageDimensions(base64Data) {
+    return new Promise((resolve) => {
+        const img = createImageFromBase64(base64Data);
+        if (img.complete && (img.naturalWidth || img.width)) {
+            resolve({ width: img.naturalWidth || img.width, height: img.naturalHeight || img.height });
+        } else {
+            img.onload = function() {
+                resolve({ width: img.naturalWidth || img.width, height: img.naturalHeight || img.height });
+            };
+            img.onerror = function() {
+                resolve({ width: 1, height: 1 });
+            };
+        }
+    });
+}
+
 export {
     compressImage,
     convertBlobToBase64Icon,
-    createImageFromBase64
-}; 
+    createImageFromBase64,
+    getImageDimensions
+};


### PR DESCRIPTION
## Summary
- preserve icon aspect ratio when rendering to PDF
- expose helper for getting image dimensions
- pass compression level to PDF renderer

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685903b599e48328b11abc42565458c4