### PR TITLE
Fix set identifier duplication

### DIFF
--- a/src/js/modules/cardGenerator.js
+++ b/src/js/modules/cardGenerator.js
@@ -53,14 +53,15 @@ function generateBingoCards(options) {
         throw new Error(`Not enough icons. Need at least ${iconsNeededPerSet} ${modeInfo}`);
     }
     
-    // Generate a unique identifier for this set
+    // Generate an overall identifier for this batch
     const identifier = generateIdentifier();
-    
+
     // Generate the sets
     const cardSets = [];
     for (let setIndex = 0; setIndex < setCount; setIndex++) {
         const set = {
             id: `set-${setIndex + 1}`,
+            identifier: generateIdentifier(),
             cards: []
         };
         

--- a/src/js/modules/pdfGenerator.js
+++ b/src/js/modules/pdfGenerator.js
@@ -140,41 +140,33 @@ async function generateOnePerPageLayout(pdf, cardSets, identifier, imgQuality, s
         }
         
         let pageCount = 0;
-        
-        // Add set identifier on first page - display without "ID:" prefix
-        const displayIdentifier = identifier.replace(/^ID:/, '');
-        pdf.setFontSize(16);
-        pdf.setTextColor(100, 100, 100);
-        // Right side identifier
-        pdf.text(displayIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
-        // Left side identifier
-        pdf.text(displayIdentifier, margin, margin - 5, { align: 'left' });
-        
+
         // Process each card set
         for (let s = 0; s < cardSets.length; s++) {
             const set = cardSets[s];
-            
+            const displayIdentifier = (set.identifier || identifier).replace(/^ID:/, '');
+
             // Process each card in the set
             for (let c = 0; c < set.cards.length; c++) {
                 const card = set.cards[c];
-                
+
                 // Add a new page for each card except the first one
                 if (pageCount > 0) {
                     try {
                         pdf.addPage();
-                        // Add identifier on each page - display without "ID:" prefix
-                        const displayIdentifier = identifier.replace(/^ID:/, '');
-                        pdf.setFontSize(16);
-                        pdf.setTextColor(100, 100, 100);
-                        // Right side identifier
-                        pdf.text(displayIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
-                        // Left side identifier
-                        pdf.text(displayIdentifier, margin, margin - 5, { align: 'left' });
                     } catch (pageError) {
                         console.error('Error adding new page:', pageError);
                     }
                 }
                 pageCount++;
+
+                // Add identifier on each page - display without "ID:" prefix
+                pdf.setFontSize(16);
+                pdf.setTextColor(100, 100, 100);
+                // Right side identifier
+                pdf.text(displayIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
+                // Left side identifier
+                pdf.text(displayIdentifier, margin, margin - 5, { align: 'left' });
                 
                 // Calculate position to center the card on the page for consistent rendering
                 const availableWidth = pageWidth - (2 * margin);
@@ -264,20 +256,11 @@ async function generateTwoPerPageLayout(pdf, cardSets, identifier, imgQuality, s
         
         let cardCount = 0;
         let pageCount = 0;
-        
-        // Add set identifier on first page - on both halves (right aligned)
-        const displayIdentifier = identifier.replace(/^ID:/, '');
-        pdf.setFontSize(16);
-        pdf.setTextColor(100, 100, 100);
-        // Right side of page
-        pdf.text(displayIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
-        // Right side of left half
-        pdf.text(displayIdentifier, leftMargin + cardWidth, margin - 5, { align: 'right' });
-        
+
         // Process each card set
         for (let s = 0; s < cardSets.length; s++) {
             const set = cardSets[s];
-            
+            const setIdentifier = (set.identifier || identifier).replace(/^ID:/, '');
             // Process each card in the set
             for (let c = 0; c < set.cards.length; c++) {
                 const card = set.cards[c];
@@ -306,32 +289,27 @@ async function generateTwoPerPageLayout(pdf, cardSets, identifier, imgQuality, s
                                     console.warn('Second addPage method failed, using simple fallback:', e2);
                                     // Last resort - simple addPage and manually set orientation
                                     pdf.addPage();
-                                    // Some versions of jsPDF need this to maintain landscape orientation
                                     if (typeof pdf.setPageFormat === 'function') {
                                         pdf.setPageFormat([pageWidth, pageHeight], 'landscape');
                                     }
                                 }
                             }
                         }
-                        
+
                         pageCount++;
-                        
-                        // Add identifier on each page - right side of both halves
-                        const displayIdentifier = identifier.replace(/^ID:/, '');
-                        pdf.setFontSize(16);
-                        pdf.setTextColor(100, 100, 100);
-                        // Right side of page
-                        pdf.text(displayIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
-                        // Right side of left half
-                        pdf.text(displayIdentifier, leftMargin + cardWidth, margin - 5, { align: 'right' });
-                        
-                        // Log dimensions after adding page to verify
-                        console.log(`New page dimensions: Width=${pdf.internal.pageSize.getWidth()}, Height=${pdf.internal.pageSize.getHeight()}`);
                     } catch (pageError) {
                         console.error('Error adding new page:', pageError);
                         // If all specific methods fail, try simplest version
                         pdf.addPage();
                     }
+                }
+
+                // Add identifier at the top of each new page
+                if (cardPosition === 0) {
+                    pdf.setFontSize(16);
+                    pdf.setTextColor(100, 100, 100);
+                    pdf.text(setIdentifier, pageWidth - margin, margin - 5, { align: 'right' });
+                    pdf.text(setIdentifier, leftMargin + cardWidth, margin - 5, { align: 'right' });
                 }
                 
                 // Position cards differently based on environment

--- a/tests/js/modules/cardGenerator.test.js
+++ b/tests/js/modules/cardGenerator.test.js
@@ -38,6 +38,31 @@ describe('Card Generator', () => {
       expect(result.cardSets.length).toBe(1); // 1 set requested
     });
 
+    it('should assign a unique identifier to each set', () => {
+      const mockIcons = Array.from({ length: 9 }, (_, i) => ({
+        id: i + 1,
+        data: `data:image/png;base64,test${i + 1}`,
+        name: `test${i + 1}.png`
+      }));
+
+      const options = {
+        icons: mockIcons,
+        gridSize: 3,
+        setCount: 2,
+        cardsPerSet: 1,
+        title: 'Test Bingo',
+        leaveCenterBlank: false
+      };
+
+      const result = generateBingoCards(options);
+      expect(result.cardSets.length).toBe(2);
+      const id1 = result.cardSets[0].identifier;
+      const id2 = result.cardSets[1].identifier;
+      expect(id1).toMatch(/^ID:[A-Z0-9]{3}$/);
+      expect(id2).toMatch(/^ID:[A-Z0-9]{3}$/);
+      expect(id1).not.toBe(id2);
+    });
+
     it('should handle empty icons array', () => {
       const options = {
         icons: [],

--- a/tests/js/modules/cardGenerator.test.js
+++ b/tests/js/modules/cardGenerator.test.js
@@ -39,6 +39,11 @@ describe('Card Generator', () => {
     });
 
     it('should assign a unique identifier to each set', () => {
+      // Mock generateIdentifier to return deterministic values
+      const mockGenerateIdentifier = jest.fn()
+        .mockReturnValueOnce('ID:AAA')
+        .mockReturnValueOnce('ID:BBB');
+      jest.spyOn(require('@/js/modules/cardGenerator.js'), 'generateIdentifier').mockImplementation(mockGenerateIdentifier);
       const mockIcons = Array.from({ length: 9 }, (_, i) => ({
         id: i + 1,
         data: `data:image/png;base64,test${i + 1}`,


### PR DESCRIPTION
## Summary
- generate a unique identifier for each set when creating cards
- pass each set identifier into PDF generation and print it on every page
- test that each set has a unique identifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685903f573648328ae29696bf49342fb