### PR TITLE
Fix same card toggle missing from main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,14 @@
           <span data-translate="centerBlankToggle">Leave center cell blank (odd grids only)</span>
         </label>
       </div>
-      
+
+      <div class="form-group">
+        <label for="sameCardToggle" class="checkbox-label">
+          <input type="checkbox" id="sameCardToggle">
+          <span data-translate="sameCardToggle">Use identical card for all players</span>
+        </label>
+      </div>
+
       <div class="form-group">
         <label for="multiHitToggle" class="checkbox-label">
           <input type="checkbox" id="multiHitToggle">


### PR DESCRIPTION
## Summary
- add the missing Same Card toggle to the main `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685920bc184483288f123b7c2374a0d5