### PR TITLE
Checkpoint WAL after seeding so default icons are durable

### DIFF
--- a/src/js/modules/sqliteStorage.js
+++ b/src/js/modules/sqliteStorage.js
@@ -139,6 +139,15 @@ class SQLiteStorage {
         }
       }
 
+      // Force the bulk-inserted rows out of the WAL into the main database
+      // file immediately, so the seed is durable even if the -wal file is
+      // later lost (e.g. removed by tooling) before an automatic checkpoint.
+      try {
+        this.db.pragma('wal_checkpoint(TRUNCATE)');
+      } catch (error) {
+        console.error('WAL checkpoint after seeding failed:', error.message);
+      }
+
       console.log(`Seeded ${seeded} default icons into empty database`);
       return seeded;
     } catch (error) {


### PR DESCRIPTION
## Problem

After deploying the icon seed, the LXC ended up with only **40 of 77** icons — and the missing ones were a clean alphabetical tail (House…Wood), i.e. the last ones inserted. The startup log said "Seeded 77", so insertion succeeded; the rows were lost afterwards.

**Cause:** the seed's bulk inserts went to the SQLite **WAL**. An automatic checkpoint persisted only the first ~40 rows into the main `.db`; the rest were still in the `-wal` file when it was lost. (The original trigger was `-wal`/`-shm` being tracked in git and removed by `git reset --hard` during a deploy — already fixed by untracking them — but the seed shouldn't rely on the WAL surviving.)

## Fix

Force `PRAGMA wal_checkpoint(TRUNCATE)` immediately after the bulk seed, so every seeded row is written into the main database file at once.

**Verified:** seed → delete `-wal`/`-shm` → reopen → main `.db` still holds all **77** icons (before the fix this dropped to 40). Full suite **214/214 green**.

> Note: existing LXC databases stuck at 40 are repaired by clearing icons and restarting (re-seeds durably). Fresh installs are correct from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)