### PR TITLE
PDF label fix + support replacing an icon image via PUT

### DIFF
--- a/src/js/modules/pdfGenerator.js
+++ b/src/js/modules/pdfGenerator.js
@@ -552,9 +552,12 @@ async function renderCard(pdf, card, x, y, availableWidth, titleFontSize, labelF
         pdf.setLineWidth(0.200025);
         pdf.setDrawColor(0, 0, 0);
       } else if (cell.data) {
-        // Calculate padding and maximum image size
+        // Reserve a label strip at the bottom so the icon never overlaps the
+        // text; the icon is drawn only in the area above it.
         const padding = cellSize * 0.1;
-        const maxSize = cellSize - (padding * 2);
+        const labelArea = (showLabels && cell.name) ? cellSize * 0.22 : 0;
+        const imgAreaH = cellSize - labelArea;
+        const maxSize = Math.min(cellSize - (padding * 2), imgAreaH - padding);
 
         // Draw image with preserved aspect ratio
         try {
@@ -587,7 +590,7 @@ async function renderCard(pdf, card, x, y, availableWidth, titleFontSize, labelF
           }
 
           const offsetX = cellX + ((cellSize - drawWidth) / 2);
-          const offsetY = cellY + ((cellSize - drawHeight) / 2);
+          const offsetY = cellY + ((imgAreaH - drawHeight) / 2);
 
           // Add image to PDF
           pdf.addImage(
@@ -636,39 +639,16 @@ async function renderCard(pdf, card, x, y, availableWidth, titleFontSize, labelF
           );
         }
                 
-        // Show label if enabled - moved outside the try/catch to ensure labels appear
+        // Label sits in the reserved bottom strip, so no background bar is
+        // needed and it never covers the icon.
         if (showLabels && cell.name) {
           pdf.setFontSize(labelFontSize);
           pdf.setTextColor(0, 0, 0);
-                    
-          // Draw with white background for readability
-          const textX = cellX + (cellSize / 2);
-          const textY = cellY + cellSize - (padding / 2);
-                    
-          // Check if getTextWidth is available (it might not be in test mocks)
-          let textWidth = cell.name.length * (labelFontSize * 0.6); // Fallback calculation
-          if (typeof pdf.getTextWidth === 'function') {
-            textWidth = pdf.getTextWidth(cell.name);
-          }
-                    
-          // White pill behind the label so it stays legible over imagery
-          if (typeof pdf.setFillColor === 'function' && typeof pdf.roundedRect === 'function') {
-            pdf.setFillColor(255, 255, 255);
-            pdf.roundedRect(
-              textX - (textWidth / 2) - 1,
-              textY - labelFontSize,
-              textWidth + 2,
-              labelFontSize + 1,
-              0.8, 0.8,
-              'F'
-            );
-          }
-                    
           pdf.text(
             cell.name,
-            textX,
-            textY,
-            { align: 'center' }
+            cellX + (cellSize / 2),
+            cellY + cellSize - (labelArea / 2),
+            { align: 'center', baseline: 'middle' }
           );
         }
       }

--- a/src/js/modules/sqliteStorage.js
+++ b/src/js/modules/sqliteStorage.js
@@ -829,7 +829,21 @@ class SQLiteStorage {
       updates.push('exclude_from_multi_hit = ?');
       values.push(iconData.excludeFromMultiHit ? 1 : 0);
     }
-    
+
+    // Allow replacing the icon image (base64 data URL) in place
+    const newImage = iconData.imageData || iconData.image;
+    if (typeof newImage === 'string' && newImage.startsWith('data:')) {
+      const [mimePrefix, base64String] = newImage.split(',');
+      const mimeType = mimePrefix.match(/data:(.*?);/)[1];
+      const blobData = Buffer.from(base64String, 'base64');
+      updates.push('data = ?');
+      values.push(blobData);
+      updates.push('type = ?');
+      values.push(mimeType);
+      updates.push('size = ?');
+      values.push(blobData.length);
+    }
+
     if (updates.length === 0) {
       throw new Error('No fields to update');
     }

--- a/tests/js/modules/sqliteStorage.test.js
+++ b/tests/js/modules/sqliteStorage.test.js
@@ -212,6 +212,27 @@ describe('SQLiteStorage', () => {
       });
     });
 
+    describe('updateIcon image replacement', () => {
+      const PNG1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB' +
+        'CAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+      test('replaces the icon image while keeping other fields', async () => {
+        await storage.saveIcon({ id: 'img-upd', name: 'Cow', image: PNG1, category: 'Animals', difficulty: 4 });
+        const before = (await storage.loadIcons()).find(i => i.id === 'img-upd');
+
+        // A different 1x1 png (red) to force a new blob
+        const PNG2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB' +
+          'CAYAAAAfFcSJAAAADklEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+        await storage.updateIcon('img-upd', { imageData: PNG2 });
+
+        const after = (await storage.loadIcons()).find(i => i.id === 'img-upd');
+        expect(after.name).toBe('Cow');
+        expect(after.category).toBe('Animals');
+        expect(after.difficulty).toBe(4);
+        expect(after.image).not.toBe(before.image); // blob changed
+      });
+    });
+
     describe('clearIcons', () => {
       test('should delete all icons', async () => {
         const testIcons = [


### PR DESCRIPTION
The bingo label sat in a white background pill at the bottom of each cell while the icon was centered in the **whole** cell, so the pill (and label) overlapped the lower part of the icon.

Fix: reserve a label strip at the bottom of the cell, draw the icon only in the area above it, and drop the now-unneeded white pill. Verified by regenerating a PDF — labels sit cleanly below the icons with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)